### PR TITLE
Matt/chordsynthseperatefiles

### DIFF
--- a/components/CombChord.js
+++ b/components/CombChord.js
@@ -1,0 +1,31 @@
+//used by chord to look up midi values
+let octave = {
+  'C':60,'C#':61,'D':62,'D#':63,'E':64,'F':65,'F#':66,'G':67,'G#':68,'A':69,'A#':70,'B':71};
+
+/*
+a chord object containing data about which notes are to be played
+root: root note of chord
+qual: "quality of chord" eg: maj/min/dim etc
+synth: Synth object which will actually play the notes
+
+future: more qualitys, extensions, various methods. This class is intended to be part of the
+Cell model class.  
+*/ 
+class Chord{
+  constructor(root,qual,synth){
+    this.root = root;
+    this.rootMidiNote = octave[root];
+    this.qual = (qual == null ? '' : qual);
+    this.third = (this.qual == "m" ? this.rootMidiNote + 3 : this.root + 4);
+    this.fifth = this.root + 7;
+    this.synth = synth;    
+  }
+  
+  play(){
+    this.synth.play(this.root,this.third,this.fifth);
+  }
+
+  stop(){
+    this.synth.stop();
+  }
+}

--- a/components/CombSynth.js
+++ b/components/CombSynth.js
@@ -1,0 +1,27 @@
+/*
+Synth object will play the notes. global and persistant so that all chords can share the synth
+currently set up with only 3 voices for simplicity
+future: add an amp envelope, this will need a gui at some point to edit it's attributes
+(another screen for this) 
+*/
+class Synth{
+  constructor(){
+    this.voices = [
+      (new p5.SinOsc()),
+      (new p5.SinOsc()),
+      (new p5.SinOsc())
+    ]; 
+  }
+
+  play(root,third,fifth){ 
+    this.voices[0].freq(midiToFreq(root));
+    this.voices[1].freq(midiToFreq(third));
+    this.voices[2].freq(midiToFreq(fifth));
+    
+    this.voices.map(v => v.start())
+  }
+
+  stop(){
+    this.voices.map(v => v.stop());
+  }
+}

--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
     <script src="p5/p5.min.js"></script>
     <script src="p5/addons/p5.dom.min.js"></script>
     <script src="p5/addons/p5.sound.min.js"></script>
+    <script src="components/CombSynth.js"></script>
+    <script src="components/CombChord.js"></script>
     <script src="components/Screen.js"></script>
     <script src="components/CombCell.js"></script>
     <script src="components/CombCellGrid.js"></script>

--- a/main.js
+++ b/main.js
@@ -1,70 +1,12 @@
 p5.disableFriendlyErrors = true;
 
-/* early prototypes for chord/synth objects   */
 
-//used by chord to look up midi values
-let octave = {
-  'C':60,'C#':61,'D':62,'D#':63,'E':64,'F':65,'F#':66,'G':67,'G#':68,'A':69,'A#':70,'B':71};
-
-/*
-a chord object containing data about which notes are to be played
-root: root note of chord
-qual: "quality of chord" eg: maj/min/dim etc
-synth: Synth object which will actually play the notes
-
-future: more qualitys, extensions, various methods. This class is intended to be part of the
-Cell model class.  
-*/ 
-class Chord{
-  constructor(root,qual,synth){
-    this.root = root;
-    this.rootMidiNote = octave[root];
-    this.qual = (qual == null ? '' : qual);
-    this.third = (this.qual == "m" ? this.rootMidiNote + 3 : this.root + 4);
-    this.fifth = this.root + 7;
-    this.synth = synth;    
-  }
-  
-  play(){
-    this.synth.play(this.root,this.third,this.fifth);
-  }
-
-  stop(){
-    this.synth.stop();
-  }
-}
-
-/*
-Synth object will play the notes. global and persistant so that all chords can share the synth
-currently set up with only 3 voices for simplicity
-future: add an amp envelope, this will need a gui at some point to edit it's attributes
-(another screen for this) 
-*/
-class Synth{
-  constructor(){
-    this.voices = [
-      (new p5.SinOsc()),
-      (new p5.SinOsc()),
-      (new p5.SinOsc())
-    ]; 
-  }
-
-  play(root,third,fifth){ 
-    this.voices[0].freq(midiToFreq(root));
-    this.voices[1].freq(midiToFreq(third));
-    this.voices[2].freq(midiToFreq(fifth));
-    
-    this.voices.map(v => v.start())
-  }
-
-  stop(){
-    this.voices.map(v => v.stop());
-  }
-}
 
 /*
 main for Comb project.
 */
+
+
 
 /***  processing functions ***/
 


### PR DESCRIPTION
the chord and synth classes were just sitting in the main.js file. This was meant to be a temporary thing while I was prototyping them and playing with them. I didn't make any other changes to the files, I just moved them into their own thing and updated index.html to include the "new" scripts.