### PR TITLE
Matt/inher

### DIFF
--- a/components/CombCell.js
+++ b/components/CombCell.js
@@ -10,16 +10,15 @@ that serves as an identifier.
 
 CAN:
 -display basic shape with fill color
--detect mouseIsPressed over individual Cells, and respond accordingly. Changes color atm
--keep track of how many cells there are, and each cell is numbered in draw order currently
--be used publicly without exposing implementation
+-detect mouseIsPressed over individual Cells, and respond accordingly. Changes color.
+-keep track of how many cells there are, and each cell is numbered in draw order
+
 CAN'T:
 -model components are mostly unimplemented
 -play chords yet
 
 DEPENDS ON:
 p5.js
-
 */
 
 
@@ -51,19 +50,19 @@ class CellView extends Displayable{
 
   //draw mouseover detection map layer
   displayMap(){
-    noStroke();
+    noStroke(); //turns off outlines (borders can interfere with detection)
     fill(this.mapColor);
     this.polygon(this.x,this.y,this.r,this.SIDES); 
   }
 
   //draw user viewable layer
   display(){
-    stroke('GRAY');
+    stroke('GRAY'); //turn outlines back on for hex display
     fill(this.displayColor);
     this.polygon(this.x,this.y,this.r,this.SIDES);
-    fill(0);
+    fill(0); //text fill color
     textFont('Verdana');
-    textSize(this.r / 2.5);
+    textSize(this.r / 2.5); //text size is relative to the radius
     textAlign(CENTER);
     text(this.cellText,this.x,this.y + (this.r / 7));
   }

--- a/components/CombCell.js
+++ b/components/CombCell.js
@@ -2,23 +2,16 @@
 Class for Comb hex cells
 meant to function as the basic button class, particularly for the main chord grid.
 
-NOTE: this mouseover detection is ULTRA SLOW PERFORMANCE and needs to be replaced.
 HOW MOUSEOVER DETECTION WORKS:
 this class detects mouseovers with a "map" color on each shape, which is displayed before the
 user viewable display color. This color is checked against the color under the mouse when the 
-mouse is pressed (mouseIsPressed boolean check). The acutal map color doesn't matter, as long as
-it a) isn't the same color as the background, and b) the display color of the clicked button changes
-when it is clicked. This is because the event checking is done during the Cell's display stage, 
-between the mapDisplay and the user display. Effectivly a "Just In Time" event check. Cells drawn earlier
-see the mouse as hovering over the background color. Cells drawn later see the mouse as hovering over the 
-user displayable color. In this way, each button can detect mouse-over without having to be assigned 
-unique map colors, nor some elaborite coordinate range/distance formula system. I've started calling this the
-"Duckhunt" pattern.
+mouse is pressed (mouseIsPressed boolean check). Each Clickable shape displays with a different map color
+that serves as an identifier.
 
 CAN:
 -display basic shape with fill color
 -detect mouseIsPressed over individual Cells, and respond accordingly. Changes color atm
--keep track of how many cells their are, and each cell is numbered in draw order currently
+-keep track of how many cells there are, and each cell is numbered in draw order currently
 -be used publicly without exposing implementation
 CAN'T:
 -model components are mostly unimplemented
@@ -30,17 +23,16 @@ p5.js
 */
 
 
-let numberOfCells = 0;
-
 //view: responsible for displayable tasks ie drawing to the canvas
 //displayable tasks include user-viewable and non-user-viewable (mouseover map display)
-class CellView{
+class CellView extends Displayable{
   constructor(x,y,r,displayColor,mapCol){
+    super();
     this.x = x;//coords
     this.y = y;
     this.r = r;//radius
     this.cellText = '';//text to display in a cell
-    this.mapColor = red(numberOfCells);//this is the hit map color to detect mouseover events
+    this.mapColor = mapCol;//this is the hit map color to detect mouseover events
     this.displayColor = displayColor;//this is the color that the user sees. 
     this.SIDES = 6;
   }
@@ -59,12 +51,14 @@ class CellView{
 
   //draw mouseover detection map layer
   displayMap(){
+    noStroke();
     fill(this.mapColor);
     this.polygon(this.x,this.y,this.r,this.SIDES); 
   }
 
   //draw user viewable layer
   display(){
+    stroke('GRAY');
     fill(this.displayColor);
     this.polygon(this.x,this.y,this.r,this.SIDES);
     fill(0);
@@ -80,18 +74,17 @@ class CellView{
 //eg: when a button is pressed it must both notify the view to alter display
 //and model to signal the audio engine
 class CellController{
-  constructor(v,m){
+  constructor(v,m,id){
     this.cellView = v;
     this.cellModel = m;
     this.cellData = this.cellModel.data;
     this.cellView.cellText = this.cellModel.chord.root + this.cellModel.chord.qual;//text to display in a cell
-    this.cellNumber = numberOfCells;//cellNumber is a global variable to keep # of cells
-    numberOfCells++; 
+    this.cellNumber = id;//cellNumber is a global variable to keep # of cells
+    // numberOfCells++; 
   }
 
   eventClickedMouseOver(){
     if(mouseIsPressed && red( colorUnderMouse() /* get(mouseX, mouseY)*/ ) == red(this.cellView.mapColor)){
-      console.log("event triggered!");
       this.cellView.displayColor = 'BLACK';
       console.log(this.cellNumber);//print the current cell number
     }else{
@@ -113,11 +106,12 @@ class CellModel{
 
 //wrapper class for cell components
 //functions as a public API object in order to hide MVC implimentation
-class Cell{
+class Cell extends Clickable{
   constructor(x,y,r,displayColor,mapCol,chord){
-    this.cellView = new CellView(x,y,r,displayColor,(mapCol == null ? 'WHITE' : mapCol));
+    super();
+    this.cellView = new CellView(x,y,r,displayColor,this.clickMapColor);
     this.cellModel = new CellModel(chord);
-    this.cellController = new CellController(this.cellView,this.cellModel);
+    this.cellController = new CellController(this.cellView,this.cellModel,this.clickID);
   }
 
   displayMap(){

--- a/components/CombCellGrid.js
+++ b/components/CombCellGrid.js
@@ -1,11 +1,11 @@
 /*
 collection of cells into a grid.
 The central lower cluster cell is the initial draw point for the grid.
-Is polite enough to return the draw point to where it was before the shape was
 
 CAN:
 -display a grid of cells to represent a key
 -assign chords to cells (currently just strings rather than actual chord objects)
+-be a good citizen: returns the draw point to it's position before the grid is drawn 
 
 CAN'T:
 -do much yet
@@ -27,7 +27,6 @@ class CellGrid extends Displayable{
   //builds a grid of displayable cells starting from the middle of the grid
   makeCells(startX, startY){
     let tempArray = []; //stored array of new cells   
-    const SIDES = 6; //# of sides in a cell
 
     //these variables are used to assign chords to cells based on key
     let keys = ['A','A#','B','C','C#','D','D#','E','F','F#','G','G#'];
@@ -82,15 +81,17 @@ class CellGrid extends Displayable{
   }
 
   displayMap(){
+    push();
     translate(this.x,this.y);//put the grid where it's at
     this.cells.map(cell => cell.displayMap());
+    pop();
   }
 
-  //are push()/pop() needed here?
+  //push() and pop() are needed here to return the draw point to default (or whatever it was before) 
   display(){
-    //push();
+    push(); // saves the current draw point
     translate(this.x,this.y);//put the grid where it's at
     this.cells.map(cell => cell.display());
-    //pop();
+    pop(); // returns the draw point to when it was saved.
   }
 }

--- a/components/CombCellGrid.js
+++ b/components/CombCellGrid.js
@@ -13,11 +13,12 @@ CAN'T:
 DEPENDS ON: CombCell.js
 */
 
-class CellGrid{
+class CellGrid extends Displayable{
   constructor(x,y,cellSize,key){
+    super();
     this.x = x;//x and y positions of the center (V chord) cell
     this.y = y;
-    this.SPACING = 1.75; //space between cells in grid
+    this.SPACING = 1.77; //space between cells in grid
     this.key = key;
     this.cellSize = cellSize;
     this.cells = this.makeCells();

--- a/components/CombCellGrid.js
+++ b/components/CombCellGrid.js
@@ -7,9 +7,6 @@ CAN:
 -assign chords to cells (currently just strings rather than actual chord objects)
 -be a good citizen: returns the draw point to it's position before the grid is drawn 
 
-CAN'T:
--do much yet
-
 DEPENDS ON: CombCell.js
 */
 
@@ -80,6 +77,7 @@ class CellGrid extends Displayable{
     return tempArray;
   }
 
+  //push() and pop() are needed here to return the draw point to default (or whatever it was before)
   displayMap(){
     push();
     translate(this.x,this.y);//put the grid where it's at

--- a/components/Skeletons.js
+++ b/components/Skeletons.js
@@ -1,10 +1,20 @@
 //in lew of static js class variables (until/if we figure those out)
 //this variable keeps count of the # of Clickable instances
-//used as an id number and   
+//used as an id number and map color
 let clickableCount = 0;
 
 //base class for anything displayable.
 class Displayable{
+  
+  //the display map is the version of the shape drawn under the
+  //user displayable layer. It's for event detection of mouse rollovers
+  //it's in the Displayable class because many displayable objects may not
+  //be clickable themselves, but be made up of clickable objects. this method
+  //should be used to call the clickable objects displayMap() method. 
+  //a good example can be found in the CombCellGrid class.
+  displayMap(){ 
+  }
+  
   display(){
   }
 }
@@ -13,12 +23,8 @@ class Displayable{
 class Clickable extends Displayable{
   constructor(){
     super();
-    clickableCount++;
+    clickableCount+=1;
     this.clickID = clickableCount;
-    this.mapColor = this.clickID;  
-  }
-  //the display map is the version of the shape drawn under the
-  //user displayable layer. It's for event detection of mouse rollovers
-  displayMap(){
+    this.clickMapColor = this.clickID;  
   }
 }

--- a/components/Skeletons.js
+++ b/components/Skeletons.js
@@ -1,0 +1,24 @@
+//in lew of static js class variables (until/if we figure those out)
+//this variable keeps count of the # of Clickable instances
+//used as an id number and   
+let clickableCount = 0;
+
+//base class for anything displayable.
+class Displayable{
+  display(){
+  }
+}
+
+//base class for anything clickable 
+class Clickable extends Displayable{
+  constructor(){
+    super();
+    clickableCount++;
+    this.clickID = clickableCount;
+    this.mapColor = this.clickID;  
+  }
+  //the display map is the version of the shape drawn under the
+  //user displayable layer. It's for event detection of mouse rollovers
+  displayMap(){
+  }
+}

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <script src="p5/p5.min.js"></script>
     <script src="p5/addons/p5.dom.min.js"></script>
     <script src="p5/addons/p5.sound.min.js"></script>
+    <script src="components/Skeletons.js"></script>
     <script src="components/CombSynth.js"></script>
     <script src="components/CombChord.js"></script>
     <script src="components/Screen.js"></script>

--- a/index.html
+++ b/index.html
@@ -7,12 +7,14 @@
     <script src="p5/p5.min.js"></script>
     <script src="p5/addons/p5.dom.min.js"></script>
     <script src="p5/addons/p5.sound.min.js"></script>
+
     <script src="components/Skeletons.js"></script>
     <script src="components/CombSynth.js"></script>
     <script src="components/CombChord.js"></script>
     <script src="components/Screen.js"></script>
     <script src="components/CombCell.js"></script>
     <script src="components/CombCellGrid.js"></script>
+    
     <script src="main.js"></script>
   </head>
   <body>

--- a/main.js
+++ b/main.js
@@ -18,7 +18,7 @@ let map;
 function setup() {
   frameRate(30);
   createCanvas(1440,900);
-  screens[0] = new Screen(128, [(new CellGrid(width/2,height/2,30,'C')), /*(new CellGrid(width/6,height/6,30))*/ ]); //main grid
+  screens[0] = new Screen(128, [(new CellGrid(width/2,height/2,30,'C')), /*(new CellGrid(width/6,height/6,30,'D'))*/ ]); //main grid
   //screens[1] = new Screen(128, [(new Cell(width/2,height/2,100,255,255,(new Chord("D", "min", "7"))))]); //playin' around screen
   screens[(screens[1] ? 1 : 0)].displayMap();
   

--- a/main.js
+++ b/main.js
@@ -1,11 +1,8 @@
-p5.disableFriendlyErrors = true;
-
-
+//p5.disableFriendlyErrors = true; //suppresses errors when you overwrite a p5.js function. probably just leave it commented out 
 
 /*
 main for Comb project.
 */
-
 
 
 /***  processing functions ***/
@@ -23,23 +20,24 @@ function setup() {
   screens[(screens[1] ? 1 : 0)].displayMap();
   
   loadPixels(); //load the display into the pixel buffer
-
 }
 
 function draw() {
   screens[(screens[1] ? 1 : 0)].display();
 
-  if(mouseIsPressed){
-    console.log(colorUnderMouse());
-  }
+  // DEBUGGING: display color under mouse when clicked 
+  // if(mouseIsPressed){
+  //   console.log(colorUnderMouse());
+  // }
 }
 
 // function mouseClicked(){
 //   mouseWasClicked = true;
 // }
+
 /*** ^ processing functions ^ ***/
 
-
+//https://p5js.org/reference/#/p5.Image/pixels
 function colorUnderMouse(){
   let x,y,d;
   let off, components;


### PR DESCRIPTION
This commit represents many documentation updates, fixes, and most importantly a more formal inheritance structure to the program. There are now "clickable" and "displayable" base classes from which anything that is clickable or displayable (respectively) inherits. Clickable inherits displayable since you can't be clicked if you can't be displayed. Clickable keeps track of the number of clickable objects with a variable and that number is used as the color for the click map.

Some buggy behavior has been reduced, and I added and edited a lot of the comments to make the documentation up to date. 

This commit also represents the end of the event detection card for this sprint!