### PR TITLE
Hpdfix

### DIFF
--- a/main.js
+++ b/main.js
@@ -13,6 +13,7 @@ let screens = [];
 let map;
 
 function setup() {
+  pixelDensity(1);
   frameRate(30);
   createCanvas(1440,900);
   screens[0] = new Screen(128, [(new CellGrid(width/2,height/2,30,'C')), /*(new CellGrid(width/6,height/6,30,'D'))*/ ]); //main grid
@@ -43,7 +44,7 @@ function colorUnderMouse(){
   let off, components;
   x = mouseX;
   y = mouseY;
-  d = pixelDensity();
+  d = 1; //pixelDensity();
   off = (y * width + x) * d * 4;
   components = [
     pixels[off],

--- a/main.js
+++ b/main.js
@@ -13,7 +13,7 @@ let screens = [];
 let map;
 
 function setup() {
-  pixelDensity(1);
+  pixelDensity(1); // set pix density for high dens displays
   frameRate(30);
   createCanvas(1440,900);
   screens[0] = new Screen(128, [(new CellGrid(width/2,height/2,30,'C')), /*(new CellGrid(width/6,height/6,30,'D'))*/ ]); //main grid
@@ -44,7 +44,7 @@ function colorUnderMouse(){
   let off, components;
   x = mouseX;
   y = mouseY;
-  d = 1; //pixelDensity();
+  d = 1; //depreciated: pixelDensity(); should now always be 1
   off = (y * width + x) * d * 4;
   components = [
     pixels[off],


### PR DESCRIPTION
this pull should fix the problems we were having with the high density display devices such as my laptop and Ed's Surface. Devices with something like the mac retina display have more pixels per inch than normal, and that can cause all kinds of havoc with a program that accesses the pixel array in a p5.js sketch. 

This fix simply sets the pixel density to 1 during setup, which represents normal pixel density you see on more common displays. This should make the program run as though it's always on a normal display.